### PR TITLE
Add `dashboard` CLI command with view filters

### DIFF
--- a/crates/secbind-cli/src/cmd/dashboard.rs
+++ b/crates/secbind-cli/src/cmd/dashboard.rs
@@ -1,0 +1,144 @@
+use clap::{Args, ValueEnum};
+use secbind_core::SecEnvFile;
+use std::path::PathBuf;
+
+use crate::config::default_secenv_path;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub enum DashboardView {
+    Overview,
+    Secrets,
+    Policy,
+    All,
+}
+
+#[derive(Args)]
+pub struct DashboardArgs {
+    #[arg(long)]
+    pub file: Option<PathBuf>,
+
+    #[arg(long, value_enum, default_value_t = DashboardView::All)]
+    pub view: DashboardView,
+
+    #[arg(long, help = "Show secret keys (names only), never values")]
+    pub show_keys: bool,
+}
+
+pub fn run(args: DashboardArgs) -> Result<(), Box<dyn std::error::Error>> {
+    let path = default_secenv_path(args.file);
+    let file = SecEnvFile::load(&path)?;
+
+    match args.view {
+        DashboardView::Overview => print_overview(&file),
+        DashboardView::Secrets => print_secrets(&file, args.show_keys),
+        DashboardView::Policy => print_policy(&file),
+        DashboardView::All => {
+            print_overview(&file);
+            println!();
+            print_secrets(&file, args.show_keys);
+            println!();
+            print_policy(&file);
+        }
+    }
+
+    Ok(())
+}
+
+fn print_overview(file: &SecEnvFile) {
+    println!("== SecBind Dashboard / Overview ==");
+    println!("Version:              {}", file.version);
+    println!("Environment:          {}", file.env_label);
+    println!("Secret count:         {}", file.secrets.len());
+    println!(
+        "Signature status:     {}",
+        if file.verify_signature().is_ok() {
+            "VALID"
+        } else {
+            "INVALID or MISSING"
+        }
+    );
+}
+
+fn print_secrets(file: &SecEnvFile, show_keys: bool) {
+    println!("== SecBind Dashboard / Secrets ==");
+    println!("Total sealed secrets: {}", file.secrets.len());
+
+    if show_keys {
+        if file.secrets.is_empty() {
+            println!("Secret keys:          (none)");
+        } else {
+            let mut keys: Vec<&str> = file.secrets.keys().map(String::as_str).collect();
+            keys.sort_unstable();
+            println!("Secret keys:");
+            for key in keys {
+                println!("  - {}", key);
+            }
+        }
+    } else {
+        println!("Secret keys:          hidden (use --show-keys)");
+    }
+}
+
+fn print_policy(file: &SecEnvFile) {
+    println!("== SecBind Dashboard / Policy ==");
+
+    if let Some(not_after) = file.antigens.not_after {
+        println!(
+            "Expiry (not_after):   {}",
+            not_after.format("%Y-%m-%dT%H:%M:%SZ")
+        );
+        if chrono::Utc::now() > not_after {
+            println!("Expiry status:        EXPIRED");
+        } else {
+            println!("Expiry status:        active");
+        }
+    } else {
+        println!("Expiry (not_after):   never");
+    }
+
+    match &file.antigens.environment {
+        Some(env) => println!("Environment antigen:  {}", env),
+        None => println!("Environment antigen:  (none)"),
+    }
+
+    match &file.antigens.allowed_cidr {
+        Some(cidr) => println!("CIDR antigen:         {}", cidr),
+        None => println!("CIDR antigen:         (none)"),
+    }
+
+    if file.antigens.custom_tags.is_empty() {
+        println!("Custom tags:          (none)");
+    } else {
+        println!("Custom tags:");
+        let mut tags: Vec<(&str, &str)> = file
+            .antigens
+            .custom_tags
+            .iter()
+            .map(|(key, value)| (key.as_str(), value.as_str()))
+            .collect();
+        tags.sort_unstable_by(|a, b| a.0.cmp(b.0));
+        for (key, value) in tags {
+            println!("  - {}={}", key, value);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DashboardView;
+    use clap::ValueEnum;
+
+    #[test]
+    fn dashboard_view_allows_expected_variants() {
+        let variants: Vec<String> = DashboardView::value_variants()
+            .iter()
+            .filter_map(|variant| {
+                variant
+                    .to_possible_value()
+                    .map(|value| value.get_name().to_string())
+            })
+            .collect();
+
+        assert_eq!(variants, vec!["overview", "secrets", "policy", "all"]);
+    }
+}

--- a/crates/secbind-cli/src/main.rs
+++ b/crates/secbind-cli/src/main.rs
@@ -2,6 +2,7 @@ use clap::{Parser, Subcommand};
 
 mod cmd {
     pub mod audit;
+    pub mod dashboard;
     pub mod export;
     pub mod init;
     pub mod reveal;
@@ -11,7 +12,11 @@ mod cmd {
 mod config;
 
 #[derive(Parser)]
-#[command(name = "secbind", version, about = "Post-quantum context-bound secrets manager")]
+#[command(
+    name = "secbind",
+    version,
+    about = "Post-quantum context-bound secrets manager"
+)]
 struct Cli {
     #[command(subcommand)]
     command: Commands,
@@ -25,6 +30,7 @@ enum Commands {
     Run(cmd::run::RunArgs),
     Audit(cmd::audit::AuditArgs),
     Export(cmd::export::ExportArgs),
+    Dashboard(cmd::dashboard::DashboardArgs),
 }
 
 fn main() {
@@ -36,6 +42,7 @@ fn main() {
         Commands::Run(args) => cmd::run::run(args),
         Commands::Audit(args) => cmd::audit::run(args),
         Commands::Export(args) => cmd::export::run(args),
+        Commands::Dashboard(args) => cmd::dashboard::run(args),
     };
     if let Err(e) = result {
         eprintln!("Error: {}", e);


### PR DESCRIPTION
### Motivation
- Provide an interactive CLI inspection tool to surface envelope metadata, secret keys, and antigen/policy information without unsealing secrets.
- Allow users to pick which section(s) they want to see (`overview`, `secrets`, `policy`, or `all`) and optionally reveal only sealed secret names (never values).

### Description
- Add a new `secbind dashboard` subcommand implemented in `crates/secbind-cli/src/cmd/dashboard.rs` that renders overview, secrets, and policy sections.
- Wire the new command into the CLI dispatch in `crates/secbind-cli/src/main.rs` as `Dashboard(cmd::dashboard::DashboardArgs)` and dispatch to `cmd::dashboard::run`.
- Support `--view` (a `ValueEnum` with variants `overview`, `secrets`, `policy`, `all`) and `--show-keys` which lists secret keys only and never prints values, while sorting keys and tags for deterministic output.
- Include a unit test that verifies the accepted `--view` variants to keep CLI argument behavior stable.

### Testing
- Ran `cargo test -p secbind-core` and all core tests passed (`7 passed`).
- Attempted `cargo test -p secbind-cli` but it failed in this environment due to a missing system dependency: the `dbus-1` development library required by `libdbus-sys` (pkg-config cannot find `dbus-1.pc`).
- Ran `cargo fmt` to format the modified files successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaf4a127b08332ba71f0fb0e27792a)