### PR TITLE
Digvijaysai29/migrate pq crates

### DIFF
--- a/.secenv.example
+++ b/.secenv.example
@@ -1,5 +1,5 @@
 {
-  "version": "1",
+  "version": "2",
   "env_label": "example",
   "sealing_public_key": "<base64-encoded ML-KEM-768 public key (1184 bytes)>",
   "verify_key": "<base64-encoded ML-DSA-65 verify key (1952 bytes)>",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -995,6 +995,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1052,19 +1058,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pqcrypto-dilithium"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "685de0fa68c6786559d5fcdaa414f0cd68ef3f5d162f61823bd7424cd276726f"
-dependencies = [
- "cc",
- "glob",
- "libc",
- "pqcrypto-internals",
- "pqcrypto-traits",
-]
-
-[[package]]
 name = "pqcrypto-internals"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1077,10 +1070,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "pqcrypto-kyber"
-version = "0.8.1"
+name = "pqcrypto-mldsa"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c00293cf898859d0c771455388054fd69ab712263c73fdc7f287a39b1ba000"
+checksum = "f9f812cd126a2582599478a434fea75937b4b05d234c64a49e0cea129e130528"
+dependencies = [
+ "cc",
+ "glob",
+ "libc",
+ "paste",
+ "pqcrypto-internals",
+ "pqcrypto-traits",
+]
+
+[[package]]
+name = "pqcrypto-mlkem"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb14d207f3749e8a59a026c22ceaa72d70fff931cfbf4c8d9b08f3fc56dc6e60"
 dependencies = [
  "cc",
  "glob",
@@ -1199,8 +1206,8 @@ dependencies = [
  "chrono",
  "hkdf",
  "machine-uid",
- "pqcrypto-dilithium",
- "pqcrypto-kyber",
+ "pqcrypto-mldsa",
+ "pqcrypto-mlkem",
  "pqcrypto-traits",
  "rand",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1058,6 +1058,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "pqcrypto-dilithium"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685de0fa68c6786559d5fcdaa414f0cd68ef3f5d162f61823bd7424cd276726f"
+dependencies = [
+ "cc",
+ "glob",
+ "libc",
+ "pqcrypto-internals",
+ "pqcrypto-traits",
+]
+
+[[package]]
 name = "pqcrypto-internals"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1067,6 +1080,19 @@ dependencies = [
  "dunce",
  "getrandom 0.3.4",
  "libc",
+]
+
+[[package]]
+name = "pqcrypto-kyber"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c00293cf898859d0c771455388054fd69ab712263c73fdc7f287a39b1ba000"
+dependencies = [
+ "cc",
+ "glob",
+ "libc",
+ "pqcrypto-internals",
+ "pqcrypto-traits",
 ]
 
 [[package]]
@@ -1206,6 +1232,8 @@ dependencies = [
  "chrono",
  "hkdf",
  "machine-uid",
+ "pqcrypto-dilithium",
+ "pqcrypto-kyber",
  "pqcrypto-mldsa",
  "pqcrypto-mlkem",
  "pqcrypto-traits",

--- a/README.md
+++ b/README.md
@@ -57,6 +57,17 @@ secbind seal -k DATABASE_URL -v "postgres://user:pass@db/prod" --env prod
 secbind run --env prod -- node server.js
 ```
 
+## v1 to v2 Migration
+
+If you already have a legacy `version: "1"` `.secenv`, migrate it in place:
+
+```bash
+secbind migrate --env prod --file .secenv
+```
+
+The migration decrypts secrets in memory, re-seals with v2 crypto, re-signs the envelope,
+and rotates key material in your OS keychain.
+
 ## dotenv Migration
 
 Before (`.env`):
@@ -173,7 +184,7 @@ Inspect a `.secenv` file without loading any key material:
 
 ```bash
 secbind audit --file .secenv
-# Version:       1
+# Version:       2
 # Environment:   prod
 # Secrets:       3
 # Expires:       2026-12-31T00:00:00Z

--- a/crates/secbind-cli/src/cmd/export.rs
+++ b/crates/secbind-cli/src/cmd/export.rs
@@ -1,11 +1,13 @@
 use base64::{engine::general_purpose::STANDARD, Engine as _};
 use clap::Args;
 use keyring::Entry;
-use secbind_core::{reveal, RuntimeContext, SecBindError, SecEnvFile};
+use secbind_core::{reveal_for_version, RuntimeContext, SecBindError, SecEnvFile};
 use std::path::PathBuf;
 use zeroize::Zeroize;
 
-use crate::config::{default_secenv_path, keyring_service, split_combined_sk, KEYRING_USER};
+use crate::config::{
+    default_secenv_path, keyring_service, split_combined_sk_for_version, KEYRING_USER,
+};
 
 #[derive(Args)]
 pub struct ExportArgs {
@@ -18,6 +20,7 @@ pub struct ExportArgs {
 pub fn run(args: ExportArgs) -> Result<(), Box<dyn std::error::Error>> {
     let path = default_secenv_path(args.file);
     let file = SecEnvFile::load(&path)?;
+    let version = file.envelope_version()?;
 
     file.verify_signature()?;
 
@@ -27,14 +30,14 @@ pub fn run(args: ExportArgs) -> Result<(), Box<dyn std::error::Error>> {
     let entry = Entry::new(&keyring_service(&args.env), KEYRING_USER)?;
     let sk_b64 = entry.get_password()?;
     let mut combined_sk = STANDARD.decode(&sk_b64)?;
-    let (kem_sk, _) = split_combined_sk(&combined_sk)?;
+    let (kem_sk, _) = split_combined_sk_for_version(&combined_sk, version)?;
     let kem_sk = kem_sk.to_vec();
     combined_sk.zeroize();
 
     let fp = ctx.digest();
 
     for (key, sealed) in &file.secrets {
-        let plaintext = reveal(sealed, &kem_sk, &fp)?;
+        let plaintext = reveal_for_version(version, sealed, &kem_sk, &fp)?;
         let value = String::from_utf8(plaintext)
             .map_err(|e| SecBindError::SerializationError(e.to_string()))?;
         println!("{}={}", key, value);

--- a/crates/secbind-cli/src/cmd/export.rs
+++ b/crates/secbind-cli/src/cmd/export.rs
@@ -5,7 +5,7 @@ use secbind_core::{reveal, RuntimeContext, SecBindError, SecEnvFile};
 use std::path::PathBuf;
 use zeroize::Zeroize;
 
-use crate::config::{default_secenv_path, keyring_service, KEYRING_USER};
+use crate::config::{default_secenv_path, keyring_service, split_combined_sk, KEYRING_USER};
 
 #[derive(Args)]
 pub struct ExportArgs {
@@ -27,7 +27,8 @@ pub fn run(args: ExportArgs) -> Result<(), Box<dyn std::error::Error>> {
     let entry = Entry::new(&keyring_service(&args.env), KEYRING_USER)?;
     let sk_b64 = entry.get_password()?;
     let mut combined_sk = STANDARD.decode(&sk_b64)?;
-    let kem_sk = combined_sk[..2400].to_vec();
+    let (kem_sk, _) = split_combined_sk(&combined_sk)?;
+    let kem_sk = kem_sk.to_vec();
     combined_sk.zeroize();
 
     let fp = ctx.digest();

--- a/crates/secbind-cli/src/cmd/init.rs
+++ b/crates/secbind-cli/src/cmd/init.rs
@@ -1,7 +1,7 @@
 use base64::{engine::general_purpose::STANDARD, Engine as _};
 use clap::Args;
 use keyring::Entry;
-use secbind_core::{kem_secret_key_len, SecEnvFile};
+use secbind_core::{dsa_secret_key_len_for_version, SecEnvFile};
 use std::path::PathBuf;
 use zeroize::Zeroize;
 
@@ -20,9 +20,11 @@ pub struct InitArgs {
 pub fn run(args: InitArgs) -> Result<(), Box<dyn std::error::Error>> {
     let output_path = default_secenv_path(args.output);
     let (mut file, mut combined_sk) = SecEnvFile::new(&args.env, args.ttl_hours);
+    let version = file.envelope_version()?;
 
-    let kem_len = kem_secret_key_len();
-    file.sign(&combined_sk[kem_len..])?;
+    let dsa_len = dsa_secret_key_len_for_version(version);
+    let dsa_offset = combined_sk.len() - dsa_len;
+    file.sign(&combined_sk[dsa_offset..])?;
 
     let entry = Entry::new(&keyring_service(&args.env), KEYRING_USER)?;
     entry.set_password(&STANDARD.encode(&combined_sk))?;

--- a/crates/secbind-cli/src/cmd/init.rs
+++ b/crates/secbind-cli/src/cmd/init.rs
@@ -1,7 +1,7 @@
 use base64::{engine::general_purpose::STANDARD, Engine as _};
 use clap::Args;
 use keyring::Entry;
-use secbind_core::SecEnvFile;
+use secbind_core::{kem_secret_key_len, SecEnvFile};
 use std::path::PathBuf;
 use zeroize::Zeroize;
 
@@ -21,9 +21,8 @@ pub fn run(args: InitArgs) -> Result<(), Box<dyn std::error::Error>> {
     let output_path = default_secenv_path(args.output);
     let (mut file, mut combined_sk) = SecEnvFile::new(&args.env, args.ttl_hours);
 
-    // Sign the empty envelope now so `seal` can verify it before adding the first secret.
-    // combined_sk[2400..] is the DSA secret key; sign() borrows it immutably then releases.
-    file.sign(&combined_sk[2400..])?;
+    let kem_len = kem_secret_key_len();
+    file.sign(&combined_sk[kem_len..])?;
 
     let entry = Entry::new(&keyring_service(&args.env), KEYRING_USER)?;
     entry.set_password(&STANDARD.encode(&combined_sk))?;

--- a/crates/secbind-cli/src/cmd/migrate.rs
+++ b/crates/secbind-cli/src/cmd/migrate.rs
@@ -1,0 +1,97 @@
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use clap::Args;
+use keyring::Entry;
+use secbind_core::{
+    dsa_secret_key_len_for_version, reveal_for_version, EnvelopeVersion, RuntimeContext, SecEnvFile,
+};
+use std::path::PathBuf;
+use zeroize::Zeroize;
+
+use crate::config::{
+    default_secenv_path, keyring_service, split_combined_sk_for_version, KEYRING_USER,
+};
+
+#[derive(Args)]
+pub struct MigrateArgs {
+    #[arg(long, default_value = "default")]
+    pub env: String,
+    #[arg(long)]
+    pub file: Option<PathBuf>,
+}
+
+pub fn run(args: MigrateArgs) -> Result<(), Box<dyn std::error::Error>> {
+    let path = default_secenv_path(args.file);
+    let legacy_file = SecEnvFile::load(&path)?;
+    let version = legacy_file.envelope_version()?;
+
+    if version == EnvelopeVersion::V2 {
+        println!(
+            "No migration needed: {} is already version 2",
+            path.display()
+        );
+        return Ok(());
+    }
+
+    legacy_file.verify_signature()?;
+
+    let ctx = RuntimeContext::capture(&args.env)?;
+    legacy_file.check_antigens(&ctx)?;
+
+    let entry = Entry::new(&keyring_service(&args.env), KEYRING_USER)?;
+    let old_sk_b64 = entry.get_password()?;
+    let mut old_combined_sk = STANDARD.decode(&old_sk_b64)?;
+    let (old_kem_sk, _) = split_combined_sk_for_version(&old_combined_sk, version)?;
+
+    let fp = ctx.digest();
+    let mut plaintext_secrets: Vec<(String, Vec<u8>)> =
+        Vec::with_capacity(legacy_file.secrets.len());
+
+    for (key, sealed) in &legacy_file.secrets {
+        let plaintext = reveal_for_version(version, sealed, old_kem_sk, &fp)?;
+        plaintext_secrets.push((key.clone(), plaintext));
+    }
+
+    let (mut migrated_file, mut new_combined_sk) =
+        SecEnvFile::new_for_version(&legacy_file.env_label, None, EnvelopeVersion::V2);
+    migrated_file.antigens = legacy_file.antigens.clone();
+
+    for (key, plaintext) in &plaintext_secrets {
+        migrated_file.add_secret(key, plaintext, &ctx)?;
+    }
+
+    let dsa_len = dsa_secret_key_len_for_version(EnvelopeVersion::V2);
+    let dsa_offset = new_combined_sk.len() - dsa_len;
+    migrated_file.sign(&new_combined_sk[dsa_offset..])?;
+
+    let temp_path = path.with_extension("secenv.migrating");
+    migrated_file.save(&temp_path)?;
+
+    let original_content = std::fs::read_to_string(&path)?;
+
+    std::fs::rename(&temp_path, &path)?;
+
+    let new_sk_b64 = STANDARD.encode(&new_combined_sk);
+    if let Err(e) = entry.set_password(&new_sk_b64) {
+        let _ = std::fs::write(&path, original_content);
+        old_combined_sk.zeroize();
+        new_combined_sk.zeroize();
+        for (_, plaintext) in &mut plaintext_secrets {
+            plaintext.zeroize();
+        }
+        return Err(Box::new(e));
+    }
+
+    old_combined_sk.zeroize();
+    new_combined_sk.zeroize();
+
+    for (_, plaintext) in &mut plaintext_secrets {
+        plaintext.zeroize();
+    }
+
+    println!(
+        "Migrated {} to version 2 and rotated key material",
+        path.display()
+    );
+
+    Ok(())
+}

--- a/crates/secbind-cli/src/cmd/reveal.rs
+++ b/crates/secbind-cli/src/cmd/reveal.rs
@@ -1,11 +1,13 @@
 use base64::{engine::general_purpose::STANDARD, Engine as _};
 use clap::Args;
 use keyring::Entry;
-use secbind_core::{reveal, RuntimeContext, SecBindError, SecEnvFile};
+use secbind_core::{reveal_for_version, RuntimeContext, SecBindError, SecEnvFile};
 use std::path::PathBuf;
 use zeroize::Zeroize;
 
-use crate::config::{default_secenv_path, keyring_service, split_combined_sk, KEYRING_USER};
+use crate::config::{
+    default_secenv_path, keyring_service, split_combined_sk_for_version, KEYRING_USER,
+};
 
 #[derive(Args)]
 pub struct RevealArgs {
@@ -20,13 +22,14 @@ pub struct RevealArgs {
 pub fn run(args: RevealArgs) -> Result<(), Box<dyn std::error::Error>> {
     let path = default_secenv_path(args.file);
     let file = SecEnvFile::load(&path)?;
+    let version = file.envelope_version()?;
 
     file.verify_signature()?;
 
     let entry = Entry::new(&keyring_service(&args.env), KEYRING_USER)?;
     let sk_b64 = entry.get_password()?;
     let mut combined_sk = STANDARD.decode(&sk_b64)?;
-    let (kem_sk, _) = split_combined_sk(&combined_sk)?;
+    let (kem_sk, _) = split_combined_sk_for_version(&combined_sk, version)?;
 
     let ctx = RuntimeContext::capture(&args.env)?;
     file.check_antigens(&ctx)?;
@@ -37,7 +40,7 @@ pub fn run(args: RevealArgs) -> Result<(), Box<dyn std::error::Error>> {
         .ok_or_else(|| SecBindError::EnvVarNotFound(args.key.clone()))?;
 
     let fp = ctx.digest();
-    let plaintext = reveal(sealed, kem_sk, &fp)?;
+    let plaintext = reveal_for_version(version, sealed, kem_sk, &fp)?;
 
     combined_sk.zeroize();
 

--- a/crates/secbind-cli/src/cmd/reveal.rs
+++ b/crates/secbind-cli/src/cmd/reveal.rs
@@ -5,7 +5,7 @@ use secbind_core::{reveal, RuntimeContext, SecBindError, SecEnvFile};
 use std::path::PathBuf;
 use zeroize::Zeroize;
 
-use crate::config::{default_secenv_path, keyring_service, KEYRING_USER};
+use crate::config::{default_secenv_path, keyring_service, split_combined_sk, KEYRING_USER};
 
 #[derive(Args)]
 pub struct RevealArgs {
@@ -26,6 +26,7 @@ pub fn run(args: RevealArgs) -> Result<(), Box<dyn std::error::Error>> {
     let entry = Entry::new(&keyring_service(&args.env), KEYRING_USER)?;
     let sk_b64 = entry.get_password()?;
     let mut combined_sk = STANDARD.decode(&sk_b64)?;
+    let (kem_sk, _) = split_combined_sk(&combined_sk)?;
 
     let ctx = RuntimeContext::capture(&args.env)?;
     file.check_antigens(&ctx)?;
@@ -36,12 +37,11 @@ pub fn run(args: RevealArgs) -> Result<(), Box<dyn std::error::Error>> {
         .ok_or_else(|| SecBindError::EnvVarNotFound(args.key.clone()))?;
 
     let fp = ctx.digest();
-    let plaintext = reveal(sealed, &combined_sk[..2400], &fp)?;
+    let plaintext = reveal(sealed, kem_sk, &fp)?;
 
     combined_sk.zeroize();
 
-    let value =
-        String::from_utf8(plaintext).unwrap_or_else(|_| "<binary data>".to_string());
+    let value = String::from_utf8(plaintext).unwrap_or_else(|_| "<binary data>".to_string());
     println!("{}", value);
     Ok(())
 }

--- a/crates/secbind-cli/src/cmd/run.rs
+++ b/crates/secbind-cli/src/cmd/run.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use std::process::Command;
 use zeroize::Zeroize;
 
-use crate::config::{default_secenv_path, keyring_service, KEYRING_USER};
+use crate::config::{default_secenv_path, keyring_service, split_combined_sk, KEYRING_USER};
 
 #[derive(Args)]
 pub struct RunArgs {
@@ -31,7 +31,8 @@ pub fn run(args: RunArgs) -> Result<(), Box<dyn std::error::Error>> {
     let entry = Entry::new(&keyring_service(&args.env), KEYRING_USER)?;
     let sk_b64 = entry.get_password()?;
     let mut combined_sk = STANDARD.decode(&sk_b64)?;
-    let kem_sk = combined_sk[..2400].to_vec();
+    let (kem_sk, _) = split_combined_sk(&combined_sk)?;
+    let kem_sk = kem_sk.to_vec();
     combined_sk.zeroize();
 
     let fp = ctx.digest();

--- a/crates/secbind-cli/src/cmd/run.rs
+++ b/crates/secbind-cli/src/cmd/run.rs
@@ -1,13 +1,15 @@
 use base64::{engine::general_purpose::STANDARD, Engine as _};
 use clap::Args;
 use keyring::Entry;
-use secbind_core::{reveal, RuntimeContext, SecBindError, SecEnvFile};
+use secbind_core::{reveal_for_version, RuntimeContext, SecBindError, SecEnvFile};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::process::Command;
 use zeroize::Zeroize;
 
-use crate::config::{default_secenv_path, keyring_service, split_combined_sk, KEYRING_USER};
+use crate::config::{
+    default_secenv_path, keyring_service, split_combined_sk_for_version, KEYRING_USER,
+};
 
 #[derive(Args)]
 pub struct RunArgs {
@@ -22,6 +24,7 @@ pub struct RunArgs {
 pub fn run(args: RunArgs) -> Result<(), Box<dyn std::error::Error>> {
     let path = default_secenv_path(args.file);
     let file = SecEnvFile::load(&path)?;
+    let version = file.envelope_version()?;
 
     file.verify_signature()?;
 
@@ -31,7 +34,7 @@ pub fn run(args: RunArgs) -> Result<(), Box<dyn std::error::Error>> {
     let entry = Entry::new(&keyring_service(&args.env), KEYRING_USER)?;
     let sk_b64 = entry.get_password()?;
     let mut combined_sk = STANDARD.decode(&sk_b64)?;
-    let (kem_sk, _) = split_combined_sk(&combined_sk)?;
+    let (kem_sk, _) = split_combined_sk_for_version(&combined_sk, version)?;
     let kem_sk = kem_sk.to_vec();
     combined_sk.zeroize();
 
@@ -39,7 +42,7 @@ pub fn run(args: RunArgs) -> Result<(), Box<dyn std::error::Error>> {
     let mut env_map: HashMap<String, String> = HashMap::new();
 
     for (key, sealed) in &file.secrets {
-        let plaintext = reveal(sealed, &kem_sk, &fp)?;
+        let plaintext = reveal_for_version(version, sealed, &kem_sk, &fp)?;
         let value = String::from_utf8(plaintext)
             .map_err(|e| SecBindError::SerializationError(e.to_string()))?;
         env_map.insert(key.clone(), value);

--- a/crates/secbind-cli/src/cmd/seal.rs
+++ b/crates/secbind-cli/src/cmd/seal.rs
@@ -5,7 +5,9 @@ use secbind_core::{RuntimeContext, SealingKeypair, SecEnvFile};
 use std::path::PathBuf;
 use zeroize::Zeroize;
 
-use crate::config::{default_secenv_path, keyring_service, split_combined_sk, KEYRING_USER};
+use crate::config::{
+    default_secenv_path, keyring_service, split_combined_sk_for_version, KEYRING_USER,
+};
 
 #[derive(Args)]
 pub struct SealArgs {
@@ -22,13 +24,14 @@ pub struct SealArgs {
 pub fn run(args: SealArgs) -> Result<(), Box<dyn std::error::Error>> {
     let path = default_secenv_path(args.file);
     let mut file = SecEnvFile::load(&path)?;
+    let version = file.envelope_version()?;
 
     file.verify_signature()?;
 
     let entry = Entry::new(&keyring_service(&args.env), KEYRING_USER)?;
     let sk_b64 = entry.get_password()?;
     let mut combined_sk = STANDARD.decode(&sk_b64)?;
-    let (kem_sk, dsa_sk) = split_combined_sk(&combined_sk)?;
+    let (kem_sk, dsa_sk) = split_combined_sk_for_version(&combined_sk, version)?;
 
     let ctx = RuntimeContext::capture(&args.env)?;
 

--- a/crates/secbind-cli/src/cmd/seal.rs
+++ b/crates/secbind-cli/src/cmd/seal.rs
@@ -5,7 +5,7 @@ use secbind_core::{RuntimeContext, SealingKeypair, SecEnvFile};
 use std::path::PathBuf;
 use zeroize::Zeroize;
 
-use crate::config::{default_secenv_path, keyring_service, KEYRING_USER};
+use crate::config::{default_secenv_path, keyring_service, split_combined_sk, KEYRING_USER};
 
 #[derive(Args)]
 pub struct SealArgs {
@@ -28,14 +28,15 @@ pub fn run(args: SealArgs) -> Result<(), Box<dyn std::error::Error>> {
     let entry = Entry::new(&keyring_service(&args.env), KEYRING_USER)?;
     let sk_b64 = entry.get_password()?;
     let mut combined_sk = STANDARD.decode(&sk_b64)?;
+    let (kem_sk, dsa_sk) = split_combined_sk(&combined_sk)?;
 
     let ctx = RuntimeContext::capture(&args.env)?;
 
     file.add_secret(&args.key, args.value.as_bytes(), &ctx)?;
 
     let kp = SealingKeypair {
-        kem_sk: combined_sk[..2400].to_vec(),
-        dsa_sk: combined_sk[2400..].to_vec(),
+        kem_sk: kem_sk.to_vec(),
+        dsa_sk: dsa_sk.to_vec(),
     };
     combined_sk.zeroize();
     file.sign(&kp.dsa_sk)?;

--- a/crates/secbind-cli/src/config.rs
+++ b/crates/secbind-cli/src/config.rs
@@ -1,6 +1,9 @@
 use std::path::PathBuf;
 
-use secbind_core::{combined_secret_key_len, dsa_secret_key_len, kem_secret_key_len, SecBindError};
+use secbind_core::{
+    combined_secret_key_len_for_version, dsa_secret_key_len_for_version,
+    kem_secret_key_len_for_version, EnvelopeVersion, SecBindError,
+};
 
 pub const KEYRING_USER: &str = "secbind-sk";
 
@@ -12,13 +15,17 @@ pub fn default_secenv_path(file: Option<PathBuf>) -> PathBuf {
     file.unwrap_or_else(|| PathBuf::from(".secenv"))
 }
 
-pub fn split_combined_sk(combined_sk: &[u8]) -> Result<(&[u8], &[u8]), SecBindError> {
-    let kem_len = kem_secret_key_len();
-    let dsa_len = dsa_secret_key_len();
-    let expected_len = combined_secret_key_len();
+pub fn split_combined_sk_for_version(
+    combined_sk: &[u8],
+    version: EnvelopeVersion,
+) -> Result<(&[u8], &[u8]), SecBindError> {
+    let kem_len = kem_secret_key_len_for_version(version);
+    let dsa_len = dsa_secret_key_len_for_version(version);
+    let expected_len = combined_secret_key_len_for_version(version);
     if combined_sk.len() != expected_len {
         return Err(SecBindError::SerializationError(format!(
-            "invalid keyring payload length: expected {}, got {}",
+            "invalid keyring payload length for v{}: expected {}, got {}",
+            version.as_str(),
             expected_len,
             combined_sk.len()
         )));

--- a/crates/secbind-cli/src/config.rs
+++ b/crates/secbind-cli/src/config.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 
+use secbind_core::{combined_secret_key_len, dsa_secret_key_len, kem_secret_key_len, SecBindError};
+
 pub const KEYRING_USER: &str = "secbind-sk";
 
 pub fn keyring_service(env_label: &str) -> String {
@@ -8,4 +10,21 @@ pub fn keyring_service(env_label: &str) -> String {
 
 pub fn default_secenv_path(file: Option<PathBuf>) -> PathBuf {
     file.unwrap_or_else(|| PathBuf::from(".secenv"))
+}
+
+pub fn split_combined_sk(combined_sk: &[u8]) -> Result<(&[u8], &[u8]), SecBindError> {
+    let kem_len = kem_secret_key_len();
+    let dsa_len = dsa_secret_key_len();
+    let expected_len = combined_secret_key_len();
+    if combined_sk.len() != expected_len {
+        return Err(SecBindError::SerializationError(format!(
+            "invalid keyring payload length: expected {}, got {}",
+            expected_len,
+            combined_sk.len()
+        )));
+    }
+    Ok((
+        &combined_sk[..kem_len],
+        &combined_sk[kem_len..(kem_len + dsa_len)],
+    ))
 }

--- a/crates/secbind-cli/src/main.rs
+++ b/crates/secbind-cli/src/main.rs
@@ -4,6 +4,7 @@ mod cmd {
     pub mod audit;
     pub mod export;
     pub mod init;
+    pub mod migrate;
     pub mod reveal;
     pub mod run;
     pub mod seal;
@@ -11,7 +12,11 @@ mod cmd {
 mod config;
 
 #[derive(Parser)]
-#[command(name = "secbind", version, about = "Post-quantum context-bound secrets manager")]
+#[command(
+    name = "secbind",
+    version,
+    about = "Post-quantum context-bound secrets manager"
+)]
 struct Cli {
     #[command(subcommand)]
     command: Commands,
@@ -22,6 +27,7 @@ enum Commands {
     Init(cmd::init::InitArgs),
     Seal(cmd::seal::SealArgs),
     Reveal(cmd::reveal::RevealArgs),
+    Migrate(cmd::migrate::MigrateArgs),
     Run(cmd::run::RunArgs),
     Audit(cmd::audit::AuditArgs),
     Export(cmd::export::ExportArgs),
@@ -33,6 +39,7 @@ fn main() {
         Commands::Init(args) => cmd::init::run(args),
         Commands::Seal(args) => cmd::seal::run(args),
         Commands::Reveal(args) => cmd::reveal::run(args),
+        Commands::Migrate(args) => cmd::migrate::run(args),
         Commands::Run(args) => cmd::run::run(args),
         Commands::Audit(args) => cmd::audit::run(args),
         Commands::Export(args) => cmd::export::run(args),

--- a/crates/secbind-core/Cargo.toml
+++ b/crates/secbind-core/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+pqcrypto-kyber     = "0.8"
+pqcrypto-dilithium = "0.5"
 pqcrypto-mlkem     = "0.1"
 pqcrypto-mldsa     = "0.1"
 pqcrypto-traits    = "0.3"

--- a/crates/secbind-core/Cargo.toml
+++ b/crates/secbind-core/Cargo.toml
@@ -4,15 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-# v0.2 migration: replace pqcrypto-kyber with pqcrypto-mlkem (FIPS 203 compliant ML-KEM-768).
-# Kyber Round 3 and ML-KEM-768 are algorithmically near-identical but have subtly different
-# ciphertext encodings — v1 .secenv files CANNOT be decapsulated by a strict FIPS 203
-# implementation. Ship a `secbind migrate` command before switching crates.
-# Planned replacement: pqcrypto-mlkem = "0.1" (https://crates.io/crates/pqcrypto-mlkem)
-pqcrypto-kyber     = "0.8"
-# v0.2 migration: replace pqcrypto-dilithium with pqcrypto-mldsa (FIPS 204 compliant ML-DSA-65).
-# Planned replacement: pqcrypto-mldsa = "0.1" (https://crates.io/crates/pqcrypto-mldsa)
-pqcrypto-dilithium = "0.5"
+pqcrypto-mlkem     = "0.1"
+pqcrypto-mldsa     = "0.1"
 pqcrypto-traits    = "0.3"
 chacha20poly1305   = "0.10"
 hkdf               = "0.12"

--- a/crates/secbind-core/src/crypto.rs
+++ b/crates/secbind-core/src/crypto.rs
@@ -4,7 +4,7 @@ use chacha20poly1305::{
     ChaCha20Poly1305, Key, Nonce,
 };
 use hkdf::Hkdf;
-use pqcrypto_kyber::kyber768;
+use pqcrypto_mlkem::mlkem768;
 use pqcrypto_traits::kem::{Ciphertext, PublicKey, SecretKey, SharedSecret};
 use rand::Rng;
 use serde::{Deserialize, Serialize};
@@ -31,10 +31,10 @@ pub fn seal(
     ml_kem_pk_bytes: &[u8],
     fingerprint: &[u8],
 ) -> Result<SealedSecret, SecBindError> {
-    let pk = kyber768::PublicKey::from_bytes(ml_kem_pk_bytes)
+    let pk = mlkem768::PublicKey::from_bytes(ml_kem_pk_bytes)
         .map_err(|e| SecBindError::KemError(e.to_string()))?;
 
-    let (shared_secret, kem_ct) = kyber768::encapsulate(&pk);
+    let (shared_secret, kem_ct) = mlkem768::encapsulate(&pk);
 
     let hk = Hkdf::<Sha3_512>::new(Some(fingerprint), shared_secret.as_bytes());
     let mut key_bytes = [0u8; 32];
@@ -78,12 +78,12 @@ pub fn reveal(
         ));
     }
 
-    let sk = kyber768::SecretKey::from_bytes(ml_kem_sk_bytes)
+    let sk = mlkem768::SecretKey::from_bytes(ml_kem_sk_bytes)
         .map_err(|e| SecBindError::KemError(e.to_string()))?;
-    let kem_ct = kyber768::Ciphertext::from_bytes(&kem_ct_bytes)
+    let kem_ct = mlkem768::Ciphertext::from_bytes(&kem_ct_bytes)
         .map_err(|e| SecBindError::KemError(e.to_string()))?;
 
-    let shared_secret = kyber768::decapsulate(&kem_ct, &sk);
+    let shared_secret = mlkem768::decapsulate(&kem_ct, &sk);
 
     let hk = Hkdf::<Sha3_512>::new(Some(fingerprint), shared_secret.as_bytes());
     let mut key_bytes = [0u8; 32];

--- a/crates/secbind-core/src/crypto.rs
+++ b/crates/secbind-core/src/crypto.rs
@@ -4,6 +4,7 @@ use chacha20poly1305::{
     ChaCha20Poly1305, Key, Nonce,
 };
 use hkdf::Hkdf;
+use pqcrypto_kyber::kyber768;
 use pqcrypto_mlkem::mlkem768;
 use pqcrypto_traits::kem::{Ciphertext, PublicKey, SecretKey, SharedSecret};
 use rand::Rng;
@@ -12,6 +13,7 @@ use sha3::Sha3_512;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::error::SecBindError;
+use crate::version::{EnvelopeVersion, LATEST_ENVELOPE_VERSION};
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct SealedSecret {
@@ -26,19 +28,22 @@ pub struct SealingKeypair {
     pub dsa_sk: Vec<u8>,
 }
 
-pub fn seal(
-    plaintext: &[u8],
-    ml_kem_pk_bytes: &[u8],
+fn hkdf_info_for_version(version: EnvelopeVersion) -> &'static [u8] {
+    match version {
+        EnvelopeVersion::V1 => b"secbind-v1-seal",
+        EnvelopeVersion::V2 => b"secbind-v2-seal",
+    }
+}
+
+fn encrypt_with_shared_secret(
+    shared_secret: &[u8],
     fingerprint: &[u8],
-) -> Result<SealedSecret, SecBindError> {
-    let pk = mlkem768::PublicKey::from_bytes(ml_kem_pk_bytes)
-        .map_err(|e| SecBindError::KemError(e.to_string()))?;
-
-    let (shared_secret, kem_ct) = mlkem768::encapsulate(&pk);
-
-    let hk = Hkdf::<Sha3_512>::new(Some(fingerprint), shared_secret.as_bytes());
+    info: &[u8],
+    plaintext: &[u8],
+) -> Result<(String, String), SecBindError> {
+    let hk = Hkdf::<Sha3_512>::new(Some(fingerprint), shared_secret);
     let mut key_bytes = [0u8; 32];
-    hk.expand(b"secbind-v1-seal", &mut key_bytes)
+    hk.expand(info, &mut key_bytes)
         .map_err(|_| SecBindError::KemError("HKDF expand failed".to_string()))?;
 
     let cipher = ChaCha20Poly1305::new(Key::from_slice(&key_bytes));
@@ -50,14 +55,87 @@ pub fn seal(
 
     key_bytes.zeroize();
 
-    Ok(SealedSecret {
-        kem_ciphertext: STANDARD.encode(kem_ct.as_bytes()),
-        nonce: STANDARD.encode(nonce_arr),
-        ciphertext: STANDARD.encode(ciphertext_bytes),
-    })
+    Ok((
+        STANDARD.encode(nonce_arr),
+        STANDARD.encode(ciphertext_bytes),
+    ))
 }
 
-pub fn reveal(
+fn decrypt_with_shared_secret(
+    shared_secret: &[u8],
+    fingerprint: &[u8],
+    info: &[u8],
+    nonce_bytes: &[u8],
+    ct_bytes: &[u8],
+) -> Result<Vec<u8>, SecBindError> {
+    let hk = Hkdf::<Sha3_512>::new(Some(fingerprint), shared_secret);
+    let mut key_bytes = [0u8; 32];
+    hk.expand(info, &mut key_bytes)
+        .map_err(|_| SecBindError::KemError("HKDF expand failed".to_string()))?;
+
+    let cipher = ChaCha20Poly1305::new(Key::from_slice(&key_bytes));
+    let nonce = Nonce::from_slice(nonce_bytes);
+    let plaintext = cipher
+        .decrypt(nonce, ct_bytes)
+        .map_err(|_| SecBindError::FingerprintMismatch)?;
+
+    key_bytes.zeroize();
+    Ok(plaintext)
+}
+
+pub fn seal_for_version(
+    version: EnvelopeVersion,
+    plaintext: &[u8],
+    ml_kem_pk_bytes: &[u8],
+    fingerprint: &[u8],
+) -> Result<SealedSecret, SecBindError> {
+    let info = hkdf_info_for_version(version);
+
+    match version {
+        EnvelopeVersion::V1 => {
+            let pk = kyber768::PublicKey::from_bytes(ml_kem_pk_bytes)
+                .map_err(|e| SecBindError::KemError(e.to_string()))?;
+            let (shared_secret, kem_ct) = kyber768::encapsulate(&pk);
+            let (nonce_b64, ciphertext_b64) =
+                encrypt_with_shared_secret(shared_secret.as_bytes(), fingerprint, info, plaintext)?;
+
+            Ok(SealedSecret {
+                kem_ciphertext: STANDARD.encode(kem_ct.as_bytes()),
+                nonce: nonce_b64,
+                ciphertext: ciphertext_b64,
+            })
+        }
+        EnvelopeVersion::V2 => {
+            let pk = mlkem768::PublicKey::from_bytes(ml_kem_pk_bytes)
+                .map_err(|e| SecBindError::KemError(e.to_string()))?;
+            let (shared_secret, kem_ct) = mlkem768::encapsulate(&pk);
+            let (nonce_b64, ciphertext_b64) =
+                encrypt_with_shared_secret(shared_secret.as_bytes(), fingerprint, info, plaintext)?;
+
+            Ok(SealedSecret {
+                kem_ciphertext: STANDARD.encode(kem_ct.as_bytes()),
+                nonce: nonce_b64,
+                ciphertext: ciphertext_b64,
+            })
+        }
+    }
+}
+
+pub fn seal(
+    plaintext: &[u8],
+    ml_kem_pk_bytes: &[u8],
+    fingerprint: &[u8],
+) -> Result<SealedSecret, SecBindError> {
+    seal_for_version(
+        LATEST_ENVELOPE_VERSION,
+        plaintext,
+        ml_kem_pk_bytes,
+        fingerprint,
+    )
+}
+
+pub fn reveal_for_version(
+    version: EnvelopeVersion,
     sealed: &SealedSecret,
     ml_kem_sk_bytes: &[u8],
     fingerprint: &[u8],
@@ -78,25 +156,49 @@ pub fn reveal(
         ));
     }
 
-    let sk = mlkem768::SecretKey::from_bytes(ml_kem_sk_bytes)
-        .map_err(|e| SecBindError::KemError(e.to_string()))?;
-    let kem_ct = mlkem768::Ciphertext::from_bytes(&kem_ct_bytes)
-        .map_err(|e| SecBindError::KemError(e.to_string()))?;
+    let info = hkdf_info_for_version(version);
 
-    let shared_secret = mlkem768::decapsulate(&kem_ct, &sk);
+    match version {
+        EnvelopeVersion::V1 => {
+            let sk = kyber768::SecretKey::from_bytes(ml_kem_sk_bytes)
+                .map_err(|e| SecBindError::KemError(e.to_string()))?;
+            let kem_ct = kyber768::Ciphertext::from_bytes(&kem_ct_bytes)
+                .map_err(|e| SecBindError::KemError(e.to_string()))?;
+            let shared_secret = kyber768::decapsulate(&kem_ct, &sk);
+            decrypt_with_shared_secret(
+                shared_secret.as_bytes(),
+                fingerprint,
+                info,
+                &nonce_bytes,
+                &ct_bytes,
+            )
+        }
+        EnvelopeVersion::V2 => {
+            let sk = mlkem768::SecretKey::from_bytes(ml_kem_sk_bytes)
+                .map_err(|e| SecBindError::KemError(e.to_string()))?;
+            let kem_ct = mlkem768::Ciphertext::from_bytes(&kem_ct_bytes)
+                .map_err(|e| SecBindError::KemError(e.to_string()))?;
+            let shared_secret = mlkem768::decapsulate(&kem_ct, &sk);
+            decrypt_with_shared_secret(
+                shared_secret.as_bytes(),
+                fingerprint,
+                info,
+                &nonce_bytes,
+                &ct_bytes,
+            )
+        }
+    }
+}
 
-    let hk = Hkdf::<Sha3_512>::new(Some(fingerprint), shared_secret.as_bytes());
-    let mut key_bytes = [0u8; 32];
-    hk.expand(b"secbind-v1-seal", &mut key_bytes)
-        .map_err(|_| SecBindError::KemError("HKDF expand failed".to_string()))?;
-
-    let cipher = ChaCha20Poly1305::new(Key::from_slice(&key_bytes));
-    let nonce = Nonce::from_slice(&nonce_bytes);
-    let plaintext = cipher
-        .decrypt(nonce, ct_bytes.as_ref())
-        .map_err(|_| SecBindError::FingerprintMismatch)?;
-
-    key_bytes.zeroize();
-
-    Ok(plaintext)
+pub fn reveal(
+    sealed: &SealedSecret,
+    ml_kem_sk_bytes: &[u8],
+    fingerprint: &[u8],
+) -> Result<Vec<u8>, SecBindError> {
+    reveal_for_version(
+        LATEST_ENVELOPE_VERSION,
+        sealed,
+        ml_kem_sk_bytes,
+        fingerprint,
+    )
 }

--- a/crates/secbind-core/src/envelope.rs
+++ b/crates/secbind-core/src/envelope.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use base64::{engine::general_purpose::STANDARD, Engine as _};
 use chrono::{DateTime, Duration, Utc};
-use pqcrypto_dilithium::dilithium3;
+use pqcrypto_mldsa::mldsa65;
 use pqcrypto_traits::sign::{DetachedSignature, PublicKey, SecretKey};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -35,8 +35,8 @@ impl SecEnvFile {
     pub fn new(env_label: &str, ttl_hours: Option<u64>) -> (SecEnvFile, Vec<u8>) {
         use pqcrypto_traits::kem::{PublicKey as KemPk, SecretKey as KemSk};
 
-        let (kem_pk, kem_sk) = pqcrypto_kyber::kyber768::keypair();
-        let (dsa_vk, dsa_sk) = dilithium3::keypair();
+        let (kem_pk, kem_sk) = pqcrypto_mlkem::mlkem768::keypair();
+        let (dsa_vk, dsa_sk) = mldsa65::keypair();
 
         let not_after = ttl_hours.map(|h| Utc::now() + Duration::hours(h as i64));
 
@@ -46,7 +46,7 @@ impl SecEnvFile {
             ..Default::default()
         };
 
-        let mut combined_sk = Vec::with_capacity(2400 + 4032);
+        let mut combined_sk = Vec::with_capacity(kem_sk.as_bytes().len() + dsa_sk.as_bytes().len());
         combined_sk.extend_from_slice(kem_sk.as_bytes());
         combined_sk.extend_from_slice(dsa_sk.as_bytes());
 
@@ -87,10 +87,10 @@ impl SecEnvFile {
     }
 
     pub fn sign(&mut self, dsa_sk_bytes: &[u8]) -> Result<(), SecBindError> {
-        let sk = dilithium3::SecretKey::from_bytes(dsa_sk_bytes)
+        let sk = mldsa65::SecretKey::from_bytes(dsa_sk_bytes)
             .map_err(|e| SecBindError::KemError(e.to_string()))?;
         let msg = self.signable_bytes()?;
-        let sig = dilithium3::detached_sign(&msg, &sk);
+        let sig = mldsa65::detached_sign(&msg, &sk);
         self.envelope_signature = Some(STANDARD.encode(sig.as_bytes()));
         Ok(())
     }
@@ -107,14 +107,14 @@ impl SecEnvFile {
             .decode(&self.verify_key)
             .map_err(|_| SecBindError::SignatureInvalid)?;
 
-        let sig = dilithium3::DetachedSignature::from_bytes(&sig_bytes)
+        let sig = mldsa65::DetachedSignature::from_bytes(&sig_bytes)
             .map_err(|_| SecBindError::SignatureInvalid)?;
-        let vk = dilithium3::PublicKey::from_bytes(&vk_bytes)
+        let vk = mldsa65::PublicKey::from_bytes(&vk_bytes)
             .map_err(|_| SecBindError::SignatureInvalid)?;
 
         let msg = self.signable_bytes()?;
 
-        dilithium3::verify_detached_signature(&sig, &msg, &vk)
+        mldsa65::verify_detached_signature(&sig, &msg, &vk)
             .map_err(|_| SecBindError::SignatureInvalid)
     }
 
@@ -130,10 +130,7 @@ impl SecEnvFile {
         if let Some(env) = &self.antigens.environment {
             if env != &ctx.env_label {
                 return Err(SecBindError::AntigenViolation {
-                    antigen: format!(
-                        "environment: expected '{}', got '{}'",
-                        env, ctx.env_label
-                    ),
+                    antigen: format!("environment: expected '{}', got '{}'", env, ctx.env_label),
                 });
             }
         }
@@ -158,8 +155,7 @@ impl SecEnvFile {
 
     pub fn load(path: &Path) -> Result<Self, SecBindError> {
         let content = std::fs::read_to_string(path)?;
-        serde_json::from_str(&content)
-            .map_err(|e| SecBindError::SerializationError(e.to_string()))
+        serde_json::from_str(&content).map_err(|e| SecBindError::SerializationError(e.to_string()))
     }
 
     pub fn save(&self, path: &Path) -> Result<(), SecBindError> {

--- a/crates/secbind-core/src/envelope.rs
+++ b/crates/secbind-core/src/envelope.rs
@@ -3,14 +3,16 @@ use std::path::Path;
 
 use base64::{engine::general_purpose::STANDARD, Engine as _};
 use chrono::{DateTime, Duration, Utc};
+use pqcrypto_dilithium::dilithium3;
 use pqcrypto_mldsa::mldsa65;
 use pqcrypto_traits::sign::{DetachedSignature, PublicKey, SecretKey};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::crypto::{seal as crypto_seal, SealedSecret};
+use crate::crypto::{seal_for_version as crypto_seal_for_version, SealedSecret};
 use crate::error::SecBindError;
 use crate::fingerprint::RuntimeContext;
+use crate::version::{EnvelopeVersion, LATEST_ENVELOPE_VERSION};
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]
 pub struct Antigens {
@@ -33,10 +35,38 @@ pub struct SecEnvFile {
 
 impl SecEnvFile {
     pub fn new(env_label: &str, ttl_hours: Option<u64>) -> (SecEnvFile, Vec<u8>) {
+        Self::new_for_version(env_label, ttl_hours, LATEST_ENVELOPE_VERSION)
+    }
+
+    pub fn new_for_version(
+        env_label: &str,
+        ttl_hours: Option<u64>,
+        version: EnvelopeVersion,
+    ) -> (SecEnvFile, Vec<u8>) {
         use pqcrypto_traits::kem::{PublicKey as KemPk, SecretKey as KemSk};
 
-        let (kem_pk, kem_sk) = pqcrypto_mlkem::mlkem768::keypair();
-        let (dsa_vk, dsa_sk) = mldsa65::keypair();
+        let (kem_pk_bytes, kem_sk_bytes, dsa_vk_bytes, dsa_sk_bytes) = match version {
+            EnvelopeVersion::V1 => {
+                let (kem_pk, kem_sk) = pqcrypto_kyber::kyber768::keypair();
+                let (dsa_vk, dsa_sk) = dilithium3::keypair();
+                (
+                    kem_pk.as_bytes().to_vec(),
+                    kem_sk.as_bytes().to_vec(),
+                    dsa_vk.as_bytes().to_vec(),
+                    dsa_sk.as_bytes().to_vec(),
+                )
+            }
+            EnvelopeVersion::V2 => {
+                let (kem_pk, kem_sk) = pqcrypto_mlkem::mlkem768::keypair();
+                let (dsa_vk, dsa_sk) = mldsa65::keypair();
+                (
+                    kem_pk.as_bytes().to_vec(),
+                    kem_sk.as_bytes().to_vec(),
+                    dsa_vk.as_bytes().to_vec(),
+                    dsa_sk.as_bytes().to_vec(),
+                )
+            }
+        };
 
         let not_after = ttl_hours.map(|h| Utc::now() + Duration::hours(h as i64));
 
@@ -46,21 +76,25 @@ impl SecEnvFile {
             ..Default::default()
         };
 
-        let mut combined_sk = Vec::with_capacity(kem_sk.as_bytes().len() + dsa_sk.as_bytes().len());
-        combined_sk.extend_from_slice(kem_sk.as_bytes());
-        combined_sk.extend_from_slice(dsa_sk.as_bytes());
+        let mut combined_sk = Vec::with_capacity(kem_sk_bytes.len() + dsa_sk_bytes.len());
+        combined_sk.extend_from_slice(&kem_sk_bytes);
+        combined_sk.extend_from_slice(&dsa_sk_bytes);
 
         let file = SecEnvFile {
-            version: "1".to_string(),
+            version: version.as_str().to_string(),
             env_label: env_label.to_string(),
-            sealing_public_key: STANDARD.encode(kem_pk.as_bytes()),
-            verify_key: STANDARD.encode(dsa_vk.as_bytes()),
+            sealing_public_key: STANDARD.encode(kem_pk_bytes),
+            verify_key: STANDARD.encode(dsa_vk_bytes),
             antigens,
             secrets: HashMap::new(),
             envelope_signature: None,
         };
 
         (file, combined_sk)
+    }
+
+    pub fn envelope_version(&self) -> Result<EnvelopeVersion, SecBindError> {
+        EnvelopeVersion::parse(&self.version)
     }
 
     pub fn signable_bytes(&self) -> Result<Vec<u8>, SecBindError> {
@@ -76,7 +110,7 @@ impl SecEnvFile {
             _ => {
                 return Err(SecBindError::SerializationError(
                     "expected JSON object".to_string(),
-                ))
+                ));
             }
         };
 
@@ -87,11 +121,22 @@ impl SecEnvFile {
     }
 
     pub fn sign(&mut self, dsa_sk_bytes: &[u8]) -> Result<(), SecBindError> {
-        let sk = mldsa65::SecretKey::from_bytes(dsa_sk_bytes)
-            .map_err(|e| SecBindError::KemError(e.to_string()))?;
         let msg = self.signable_bytes()?;
-        let sig = mldsa65::detached_sign(&msg, &sk);
-        self.envelope_signature = Some(STANDARD.encode(sig.as_bytes()));
+
+        let sig_bytes = match self.envelope_version()? {
+            EnvelopeVersion::V1 => {
+                let sk = dilithium3::SecretKey::from_bytes(dsa_sk_bytes)
+                    .map_err(|e| SecBindError::KemError(e.to_string()))?;
+                dilithium3::detached_sign(&msg, &sk).as_bytes().to_vec()
+            }
+            EnvelopeVersion::V2 => {
+                let sk = mldsa65::SecretKey::from_bytes(dsa_sk_bytes)
+                    .map_err(|e| SecBindError::KemError(e.to_string()))?;
+                mldsa65::detached_sign(&msg, &sk).as_bytes().to_vec()
+            }
+        };
+
+        self.envelope_signature = Some(STANDARD.encode(sig_bytes));
         Ok(())
     }
 
@@ -107,15 +152,28 @@ impl SecEnvFile {
             .decode(&self.verify_key)
             .map_err(|_| SecBindError::SignatureInvalid)?;
 
-        let sig = mldsa65::DetachedSignature::from_bytes(&sig_bytes)
-            .map_err(|_| SecBindError::SignatureInvalid)?;
-        let vk = mldsa65::PublicKey::from_bytes(&vk_bytes)
-            .map_err(|_| SecBindError::SignatureInvalid)?;
-
         let msg = self.signable_bytes()?;
 
-        mldsa65::verify_detached_signature(&sig, &msg, &vk)
-            .map_err(|_| SecBindError::SignatureInvalid)
+        match self.envelope_version()? {
+            EnvelopeVersion::V1 => {
+                let sig = dilithium3::DetachedSignature::from_bytes(&sig_bytes)
+                    .map_err(|_| SecBindError::SignatureInvalid)?;
+                let vk = dilithium3::PublicKey::from_bytes(&vk_bytes)
+                    .map_err(|_| SecBindError::SignatureInvalid)?;
+
+                dilithium3::verify_detached_signature(&sig, &msg, &vk)
+                    .map_err(|_| SecBindError::SignatureInvalid)
+            }
+            EnvelopeVersion::V2 => {
+                let sig = mldsa65::DetachedSignature::from_bytes(&sig_bytes)
+                    .map_err(|_| SecBindError::SignatureInvalid)?;
+                let vk = mldsa65::PublicKey::from_bytes(&vk_bytes)
+                    .map_err(|_| SecBindError::SignatureInvalid)?;
+
+                mldsa65::verify_detached_signature(&sig, &msg, &vk)
+                    .map_err(|_| SecBindError::SignatureInvalid)
+            }
+        }
     }
 
     pub fn check_antigens(&self, ctx: &RuntimeContext) -> Result<(), SecBindError> {
@@ -148,7 +206,8 @@ impl SecEnvFile {
             .decode(&self.sealing_public_key)
             .map_err(|e| SecBindError::SerializationError(e.to_string()))?;
         let fingerprint = ctx.digest();
-        let sealed = crypto_seal(value, &pk_bytes, &fingerprint)?;
+        let version = self.envelope_version()?;
+        let sealed = crypto_seal_for_version(version, value, &pk_bytes, &fingerprint)?;
         self.secrets.insert(key.to_string(), sealed);
         Ok(())
     }

--- a/crates/secbind-core/src/error.rs
+++ b/crates/secbind-core/src/error.rs
@@ -24,6 +24,9 @@ pub enum SecBindError {
     #[error("serialization error: {0}")]
     SerializationError(String),
 
+    #[error("unsupported envelope version: {0}")]
+    UnsupportedEnvelopeVersion(String),
+
     #[error(transparent)]
     IoError(#[from] std::io::Error),
 

--- a/crates/secbind-core/src/fingerprint.rs
+++ b/crates/secbind-core/src/fingerprint.rs
@@ -11,8 +11,7 @@ pub struct RuntimeContext {
 
 impl RuntimeContext {
     pub fn capture(env_label: &str) -> Result<Self, SecBindError> {
-        let machine_id = machine_uid::get()
-            .map_err(|e| SecBindError::KemError(e.to_string()))?;
+        let machine_id = machine_uid::get().map_err(|e| SecBindError::KemError(e.to_string()))?;
 
         let exe_path = std::env::current_exe()?;
         let exe_bytes = std::fs::read(&exe_path)?;

--- a/crates/secbind-core/src/lib.rs
+++ b/crates/secbind-core/src/lib.rs
@@ -9,6 +9,18 @@ pub use envelope::{Antigens, SecEnvFile};
 pub use error::SecBindError;
 pub use fingerprint::RuntimeContext;
 
+pub fn kem_secret_key_len() -> usize {
+    pqcrypto_mlkem::mlkem768::secret_key_bytes()
+}
+
+pub fn dsa_secret_key_len() -> usize {
+    pqcrypto_mldsa::mldsa65::secret_key_bytes()
+}
+
+pub fn combined_secret_key_len() -> usize {
+    kem_secret_key_len() + dsa_secret_key_len()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -28,7 +40,7 @@ mod tests {
     fn seal_and_reveal_roundtrip() {
         let ctx = make_ctx("test");
         let (file, combined_sk) = SecEnvFile::new("test", None);
-        let kem_sk = &combined_sk[..2400];
+        let kem_sk = &combined_sk[..kem_secret_key_len()];
         let pk_bytes = STANDARD.decode(&file.sealing_public_key).unwrap();
         let fp = ctx.digest();
         let plaintext = b"super-secret-value";
@@ -41,7 +53,7 @@ mod tests {
     fn wrong_fingerprint_fails() {
         let ctx = make_ctx("test");
         let (file, combined_sk) = SecEnvFile::new("test", None);
-        let kem_sk = &combined_sk[..2400];
+        let kem_sk = &combined_sk[..kem_secret_key_len()];
         let pk_bytes = STANDARD.decode(&file.sealing_public_key).unwrap();
         let fp = ctx.digest();
         let sealed = seal(b"secret", &pk_bytes, &fp).unwrap();
@@ -72,7 +84,7 @@ mod tests {
     fn tampered_envelope_fails_signature() {
         let ctx = make_ctx("test");
         let (mut file, combined_sk) = SecEnvFile::new("test", None);
-        let dsa_sk = &combined_sk[2400..];
+        let dsa_sk = &combined_sk[kem_secret_key_len()..];
         file.add_secret("FOO", b"bar", &ctx).unwrap();
         file.sign(dsa_sk).unwrap();
         file.secrets.get_mut("FOO").unwrap().ciphertext.push('X');
@@ -84,8 +96,9 @@ mod tests {
     fn multiple_secrets_roundtrip() {
         let ctx = make_ctx("test");
         let (mut file, combined_sk) = SecEnvFile::new("test", None);
-        let kem_sk = &combined_sk[..2400];
-        let dsa_sk = &combined_sk[2400..];
+        let kem_len = kem_secret_key_len();
+        let kem_sk = &combined_sk[..kem_len];
+        let dsa_sk = &combined_sk[kem_len..];
 
         for i in 0..10 {
             let key = format!("SECRET_{}", i);
@@ -110,8 +123,8 @@ mod tests {
         use zeroize::Zeroize;
 
         let mut kp = SealingKeypair {
-            kem_sk: vec![0xFFu8; 2400],
-            dsa_sk: vec![0xFFu8; 4032],
+            kem_sk: vec![0xFFu8; kem_secret_key_len()],
+            dsa_sk: vec![0xFFu8; dsa_secret_key_len()],
         };
         let raw_kem: *const u8 = kp.kem_sk.as_ptr();
         let raw_dsa: *const u8 = kp.dsa_sk.as_ptr();

--- a/crates/secbind-core/src/lib.rs
+++ b/crates/secbind-core/src/lib.rs
@@ -3,22 +3,44 @@ pub mod crypto;
 pub mod envelope;
 pub mod error;
 pub mod fingerprint;
+pub mod version;
 
-pub use crypto::{reveal, seal, SealedSecret, SealingKeypair};
+pub use crypto::{
+    reveal, reveal_for_version, seal, seal_for_version, SealedSecret, SealingKeypair,
+};
 pub use envelope::{Antigens, SecEnvFile};
 pub use error::SecBindError;
 pub use fingerprint::RuntimeContext;
+pub use version::{EnvelopeVersion, LATEST_ENVELOPE_VERSION};
+
+pub fn kem_secret_key_len_for_version(version: EnvelopeVersion) -> usize {
+    match version {
+        EnvelopeVersion::V1 => pqcrypto_kyber::kyber768::secret_key_bytes(),
+        EnvelopeVersion::V2 => pqcrypto_mlkem::mlkem768::secret_key_bytes(),
+    }
+}
+
+pub fn dsa_secret_key_len_for_version(version: EnvelopeVersion) -> usize {
+    match version {
+        EnvelopeVersion::V1 => pqcrypto_dilithium::dilithium3::secret_key_bytes(),
+        EnvelopeVersion::V2 => pqcrypto_mldsa::mldsa65::secret_key_bytes(),
+    }
+}
+
+pub fn combined_secret_key_len_for_version(version: EnvelopeVersion) -> usize {
+    kem_secret_key_len_for_version(version) + dsa_secret_key_len_for_version(version)
+}
 
 pub fn kem_secret_key_len() -> usize {
-    pqcrypto_mlkem::mlkem768::secret_key_bytes()
+    kem_secret_key_len_for_version(LATEST_ENVELOPE_VERSION)
 }
 
 pub fn dsa_secret_key_len() -> usize {
-    pqcrypto_mldsa::mldsa65::secret_key_bytes()
+    dsa_secret_key_len_for_version(LATEST_ENVELOPE_VERSION)
 }
 
 pub fn combined_secret_key_len() -> usize {
-    kem_secret_key_len() + dsa_secret_key_len()
+    combined_secret_key_len_for_version(LATEST_ENVELOPE_VERSION)
 }
 
 #[cfg(test)]
@@ -46,6 +68,20 @@ mod tests {
         let plaintext = b"super-secret-value";
         let sealed = seal(plaintext, &pk_bytes, &fp).unwrap();
         let revealed = reveal(&sealed, kem_sk, &fp).unwrap();
+        assert_eq!(revealed, plaintext);
+    }
+
+    #[test]
+    fn v1_seal_and_reveal_roundtrip() {
+        let ctx = make_ctx("test");
+        let (file, combined_sk) = SecEnvFile::new_for_version("test", None, EnvelopeVersion::V1);
+        let kem_len = kem_secret_key_len_for_version(EnvelopeVersion::V1);
+        let kem_sk = &combined_sk[..kem_len];
+        let pk_bytes = STANDARD.decode(&file.sealing_public_key).unwrap();
+        let fp = ctx.digest();
+        let plaintext = b"legacy-secret-value";
+        let sealed = seal_for_version(EnvelopeVersion::V1, plaintext, &pk_bytes, &fp).unwrap();
+        let revealed = reveal_for_version(EnvelopeVersion::V1, &sealed, kem_sk, &fp).unwrap();
         assert_eq!(revealed, plaintext);
     }
 

--- a/crates/secbind-core/src/version.rs
+++ b/crates/secbind-core/src/version.rs
@@ -1,0 +1,26 @@
+use crate::error::SecBindError;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum EnvelopeVersion {
+    V1,
+    V2,
+}
+
+impl EnvelopeVersion {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            EnvelopeVersion::V1 => "1",
+            EnvelopeVersion::V2 => "2",
+        }
+    }
+
+    pub fn parse(raw: &str) -> Result<Self, SecBindError> {
+        match raw {
+            "1" => Ok(EnvelopeVersion::V1),
+            "2" => Ok(EnvelopeVersion::V2),
+            other => Err(SecBindError::UnsupportedEnvelopeVersion(other.to_string())),
+        }
+    }
+}
+
+pub const LATEST_ENVELOPE_VERSION: EnvelopeVersion = EnvelopeVersion::V2;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added v2 envelope format support with improved cryptography.
  * Introduced new `migrate` command to automatically upgrade legacy configuration files from v1 to v2, including keyring key rotation.

* **Documentation**
  * Added upgrade guide with migration command and process overview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->